### PR TITLE
removed disable_dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added support for elasticsearch 6.3
 * **INCOMPATIBLE CHANGE**:
   - Dropped support for older versions
+  - Removed **disable_dynamic**
 
 ## 0.2.0
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,6 @@ class elasticsearch(
                       $nodename              = $::hostname,
                       $clustername           = 'elasticsearchcluster',
                       $network_host          = undef,
-                      $disable_dynamic       = true,
                       $discovery_multicast   = false,
                       $discovery_unicast     = [ '127.0.0.1:9300' ],
                       $path_data             = '/var/lib/elasticsearch',

--- a/templates/elasticsearch.erb
+++ b/templates/elasticsearch.erb
@@ -1,8 +1,6 @@
 # puppet managed file
 ##################### Elasticsearch Configuration Example #####################
 
-script.disable_dynamic: <%= @disable_dynamic %>
-
 # This file contains an overview of various configuration settings,
 # targeted at operations staff. Application developers should
 # consult the guide at <http://elasticsearch.org/guide>.


### PR DESCRIPTION
…===========

#
# NOTE: Elasticsearch comes with reasonable defaults for most settings.
#       Before you set out to tweak and tune the configuration, make sure you
#       understand what are you trying to accomplish and the consequences.
#
# The primary way of configuring a node is via this file. This template lists
# the most important settings you may want to configure for a production cluster.
#
# Please consult the documentation for further information on configuration options:
# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
#
# ---------------------------------- Cluster -----------------------------------
#
# Use a descriptive name for your cluster:
#
#cluster.name: my-application
#
# ------------------------------------ Node ------------------------------------
#
# Use a descriptive name for the node:
#
#node.name: node-1
#
# Add custom attributes to the node:
#
#node.attr.rack: r1
#
# ----------------------------------- Paths ------------------------------------
#
# Path to directory where to store the data (separate multiple locations by comma):
#
path.data: /var/lib/elasticsearch
#
# Path to log files:
#
path.logs: /var/log/elasticsearch
#
# ----------------------------------- Memory -----------------------------------
#
# Lock the memory on startup:
#
#bootstrap.memory_lock: true
#
# Make sure that the heap size is set to about half the memory available
# on the system and that the owner of the process is allowed to use this
# limit.
#
# Elasticsearch performs poorly when the system is swapping the memory.
#
# ---------------------------------- Network -----------------------------------
#
# Set the bind address to a specific IP (IPv4 or IPv6):
#
#network.host: 192.168.0.1
#
# Set a custom port for HTTP:
#
#http.port: 9200
#
# For more information, consult the network module documentation.
#
# --------------------------------- Discovery ----------------------------------
#
# Pass an initial list of hosts to perform discovery when new node is started:
# The default list of hosts is ["127.0.0.1", "[::1]"]
#
#discovery.zen.ping.unicast.hosts: ["host1", "host2"]
#
# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
#
#discovery.zen.minimum_master_nodes:
#
# For more information, consult the zen discovery module documentation.
#
# ---------------------------------- Gateway -----------------------------------
#
# Block initial recovery after a full cluster restart until N nodes are started:
#
#gateway.recover_after_nodes: 3
#
# For more information, consult the gateway module documentation.
#
# ---------------------------------- Various -----------------------------------
#
# Require explicit names when deleting indices:
#
#action.destructive_requires_name: true